### PR TITLE
Force dark mode theme for webapp

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,15 +3,8 @@
 @tailwind utilities;
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,12 +14,7 @@ export const metadata: Metadata = {
   title: "Rosland Web",
   description: "🤖",
   icons: {
-    icon: [
-      {
-        url: "/favicon-dark.ico",
-        media: "(prefers-color-scheme: dark)",
-      },
-    ],
+    icon: "/favicon-dark.ico",
   },
 };
 
@@ -29,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body className={`${titillium.className} antialiased`}>
         <NavBarWrapper />
         {children}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
+  darkMode: "class",
   theme: {
     extend: {
       keyframes: {


### PR DESCRIPTION
Configure webapp to always use dark mode instead of adapting to system preferences.

---
<a href="https://cursor.com/background-agent?bcId=bc-161ba525-ac4c-4b89-802e-266937228d54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-161ba525-ac4c-4b89-802e-266937228d54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

